### PR TITLE
feat: Make margins configurable

### DIFF
--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -54,19 +54,27 @@ export class TidyLayout extends Disposable {
   private nextId = 1;
   private root: InnerNode | undefined;
   private idToNode: Map<number, InnerNode> = new Map();
-  static async create(type: LayoutType = LayoutType.Tidy) {
+  static async create(
+    type: LayoutType = LayoutType.Tidy,
+    parent_child_margin = 40,
+    peer_margin = 10,
+  ) {
     await initWasm();
-    return new TidyLayout(type);
+    return new TidyLayout(type, parent_child_margin, peer_margin);
   }
 
-  private constructor(type: LayoutType = LayoutType.Tidy) {
+  private constructor(
+    type: LayoutType = LayoutType.Tidy,
+    parent_child_margin: number,
+    peer_margin: number,
+  ) {
     super();
     if (type === LayoutType.Basic) {
-      this.tidy = TidyWasm.with_basic_layout(40, 10);
+      this.tidy = TidyWasm.with_basic_layout(parent_child_margin, peer_margin);
     } else if (type === LayoutType.Tidy) {
-      this.tidy = TidyWasm.with_tidy_layout(40, 10);
+      this.tidy = TidyWasm.with_tidy_layout(parent_child_margin, peer_margin);
     } else if (type === LayoutType.LayeredTidy) {
-      this.tidy = TidyWasm.with_layered_tidy(40, 10);
+      this.tidy = TidyWasm.with_layered_tidy(parent_child_margin, peer_margin);
     } else {
       throw new Error('not implemented');
     }


### PR DESCRIPTION
(Initially accidentally opened upstream: https://github.com/zxch3n/tidy/pull/10)

To do:
- [x] ~~Check this works.~~ It does: <img width="795" alt="image" src="https://user-images.githubusercontent.com/12991097/225306237-98ff731b-d1fb-4b43-8d13-1ddef4f992fc.png">
  ~~Although there does seem to be a non-uniform gap to the right of `m` nodes~~ EDIT: this is expected, just as any other siblings can be pushed apart by their children growing large. And the weirdness with the dashed edges makes me thing that maybe we'd want this to be configurable on a per-node basis, which would be a much bigger change.
- [x] Make it configurable.
- [ ] Upstream (or at least try to).